### PR TITLE
Fix hierarchical tags structure generation

### DIFF
--- a/packages/hierarchical-tags/src/HierarchicalOperations.jsx
+++ b/packages/hierarchical-tags/src/HierarchicalOperations.jsx
@@ -87,11 +87,17 @@ export class HierarchicalOperations extends React.Component {
       let current = tagHierarchy;
       for (let i = 0; i < parts.length; i++) {
         const part = parts[i];
+        // if hierarchical structure not exists create it and add cursor for child tags
         if (current[part] === undefined) {
           current[part] = {
-            data: (i === parts.length - 1) ? data : null,
+            data: null,
             childTags: {}
           }
+        }
+
+        //if point of insert reached add operations and tag information to structure
+        if (i === parts.length - 1) {
+          current[part].data = data;
         }
         current = current[part].childTags;
       }


### PR DESCRIPTION
> @kael-shipman @Randerspl Hi guys! I found some minutes for a minor investigation. I just looked at the code and with the knowledge of the swagger ui system from back then I think this because of this lines of code: https://github.com/kael-shipman/swagger-ui-plugins/blob/hierarchical-tags/packages/hierarchical-tags/src/HierarchicalOperations.jsx#L79-L98
> 
> The `taggedOperations` selector of swagger-ui returns a map to a datastructure containing information about the tag itself and about its operations. So operations on the same level will work with the current plugin logic. But in case there are hirachical tags that end on different levels there is a issue. 
> What the plugin tries to do is to create a nested map by splitting the tags at a delimiter. In case that a nested tag at any level already exists, like in your example tag1  and tag2. And then a tag follows that ends at at a already tracked tag level like first level or second level, nothing will be done. Instead the logic should combine the operations on this level with the ones of the current tag. And probably also add the tag information if available.
> ```js
> const parts = // split tag
> for(const tag of parts) 
> {
>   // old logic if
>   else if(tag === parts[parts.length - 1])
>     //merge operations and tag info
>   //old logic
> } 
> ```
> 
> I will try to provide PR when I get home later today.
> 
> Best Regards
> Mathis
> 
> Sent from a mobile phone – please excuse the brevity of the comment.

_Originally posted by @mathis-m in https://github.com/swagger-api/swagger-ui/issues/5969#issuecomment-1172698221_

Result using [minimal reproduction json](https://github.com/swagger-api/swagger-ui/issues/5969#issuecomment-1172651176)

![image](https://user-images.githubusercontent.com/11584315/176979783-0513bc6a-0e8b-40e6-99a9-02ce1cd9fb57.png)
